### PR TITLE
[FEAT] 챌린지 메인 페이지 API 연결, 자청년 모달 수정

### DIFF
--- a/src/apis/challenge.ts
+++ b/src/apis/challenge.ts
@@ -9,15 +9,19 @@ export const getChallenges = async (
     categories?: string[]
 ) => {
     try {
+        const params = new URLSearchParams();
+        params.append("page", page.toString());
+        params.append("size", size.toString());
+        params.append("type", type);
+        if (categories) {
+            categories.forEach((category) => {
+                params.append("categories", category);
+            });
+        }
         const res = await axiosInstance.get(
             `https://www.fledge.site/api/v1/public/challenges`,
             {
-                params: {
-                    page: page,
-                    size: size,
-                    type: type,
-                    categories: categories,
-                },
+                params: params,
             }
         );
         return res.data;

--- a/src/components/Challenge/Benefit.tsx
+++ b/src/components/Challenge/Benefit.tsx
@@ -9,7 +9,7 @@ export interface BenefitProps {
 const Benefit = ({ title, price }: BenefitProps) => {
     return (
         <div>
-            <span>{title}</span>
+            <span>{title}, </span>
             <BenefitPrice>{price}</BenefitPrice> 지원
         </div>
     );

--- a/src/components/Challenge/CategoryChallenge.tsx
+++ b/src/components/Challenge/CategoryChallenge.tsx
@@ -8,7 +8,6 @@ import { useState } from "react";
 
 const CategoryChallenge = () => {
     const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
-    console.log(selectedCategories);
 
     const handleSelectCategory = (category: string) => {
         if (selectedCategories.includes(category)) {

--- a/src/components/Challenge/CategoryChallenge.tsx
+++ b/src/components/Challenge/CategoryChallenge.tsx
@@ -3,8 +3,23 @@ import tw from "twin.macro";
 import ChallengeGrid from "./ChallengeGrid";
 import ContentHeader from "../Common/ContentHeader";
 import category from "../../assets/images/challenge_category.png";
+import { challengeType } from "../../@types/challenge-category";
+import { useState } from "react";
 
 const CategoryChallenge = () => {
+    const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+    console.log(selectedCategories);
+
+    const handleSelectCategory = (category: string) => {
+        if (selectedCategories.includes(category)) {
+            setSelectedCategories(
+                selectedCategories.filter((item) => item !== category)
+            );
+        } else {
+            setSelectedCategories([...selectedCategories, category]);
+        }
+    };
+
     return (
         <Container>
             <ContentHeader
@@ -14,29 +29,23 @@ const CategoryChallenge = () => {
                 mb="-26px"
             />
             <Keywords>
-                <div>생활</div>
-                <div>주거</div>
-                <div>재정관리</div>
-                <div>취업</div>
-                <div>학습</div>
-                <div>자기계발</div>
-                <div>웰빙</div>
-                <div>자격증</div>
+                {/* 커서는 포인터, 선택되었을 경우 색상 */}
+                {challengeType.map((category) => (
+                    <div
+                        key={category.id}
+                        onClick={() => handleSelectCategory(category.id)}
+                        className={
+                            selectedCategories.includes(category.id)
+                                ? "bg-mainColor text-white"
+                                : ""
+                        }
+                    >
+                        {category.label}
+                    </div>
+                ))}
             </Keywords>
             <CategoryContainer>
-                <ChallengeGrid
-                    type="category"
-                    categories={[
-                        "생활",
-                        "주거",
-                        "재정관리",
-                        "취업",
-                        "학습",
-                        "자기계발",
-                        "웰빙",
-                        "자격증",
-                    ]}
-                />
+                <ChallengeGrid type="new" categories={selectedCategories} />
             </CategoryContainer>
         </Container>
     );
@@ -46,19 +55,19 @@ export default CategoryChallenge;
 
 const Container = styled.div`
     ${tw`
-        flex flex-col items-start relative mt-[150px] mb-[220px]
+        flex flex-col items-start relative mt-[150px] mb-[220px] w-[1400px]
     `}
 `;
 
 const Keywords = styled.div`
     ${tw`
-        flex gap-[15px] w-[1280px] relative top-[-150px] left-16
+        flex gap-[15px] w-[1280px] relative top-[-150px] left-16 text-mainColor
     `}
     div {
         ${tw`
             h-[33px] border border-mainColor border-[2px] rounded-[37px] px-[12px]
-            text-medium-20 font-medium text-mainColor flex items-center justify-center
-            bg-[250, 248, 245, 0.3]
+            text-medium-20 font-medium flex items-center justify-center
+            bg-[250, 248, 245, 0.3] cursor-pointer
         `}
     }
 `;

--- a/src/components/Challenge/ChainChallenge.tsx
+++ b/src/components/Challenge/ChainChallenge.tsx
@@ -1,28 +1,14 @@
 import styled from "styled-components";
 import tw from "twin.macro";
 import ContentHeader from "../Common/ContentHeader";
-import LeftArrowIcon from "../../assets/icons/left-arrow";
-import { ChallengeItemLarge } from "./ChallengeItem";
-import RightArrowIcon from "../../assets/icons/right-arrow";
 import chain from "../../assets/images/challenge_chain.png";
-import { useState } from "react";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import { getPartnershipChallenges } from "../../apis/challenge";
+import ChainChallengeList from "./ChainChallengeList";
 
-const ChainChallenge = () => {
-    const [page, setPage] = useState<number>(0);
+export type ChallengeGridProps = {
+    onePage?: boolean;
+};
 
-    const { data: challengeData, isLoading } = useQuery({
-        queryKey: ["getPartnershipChallenges", page],
-        queryFn: () => getPartnershipChallenges(page, 2),
-        enabled: true,
-        placeholderData: keepPreviousData,
-    });
-
-    if (isLoading) return <div></div>;
-
-    console.log(challengeData);
-
+const ChainChallenge = ({ onePage }: ChallengeGridProps) => {
     return (
         <Container>
             <ContentHeader
@@ -30,60 +16,15 @@ const ChainChallenge = () => {
                 desc="정부나 전담기관 지원 챌린지, 기업 파트너십 챌린지에 도전해보세요!"
                 imgSrc={chain}
             />
-            <ChallengerContainer>
-                <button onClick={() => setPage(page - 1)} disabled={page === 0}>
-                    <LeftArrowIcon width={24} height={51} />
-                </button>
-                <ChallengeSlider>
-                    {challengeData.data.content.map(
-                        (challenge: any, index: number) => (
-                            <ChallengeItemLarge
-                                key={index}
-                                title={challenge.title}
-                                bubbleType={challenge.type}
-                                heartCount={challenge.likeCount}
-                                challengeTypes={challenge.categories}
-                                description={challenge.description}
-                                successRate={challenge.successRate}
-                                participants={challenge.participantCount}
-                                startDate={challenge.startDate}
-                                endDate={challenge.endDate}
-                                supportContent={challenge.supportContent}
-                            />
-                        )
-                    )}
-                </ChallengeSlider>
-                <button
-                    onClick={() => setPage(page + 1)}
-                    disabled={challengeData.data.last}
-                >
-                    <RightArrowIcon width={24} height={51} />
-                </button>
-            </ChallengerContainer>
+            <ChainChallengeList onePage={onePage} />
         </Container>
     );
 };
 
 export default ChainChallenge;
 
-const ChallengerContainer = styled.div`
-    ${tw`
-        flex
-        items-center
-        justify-between
-        gap-[40px]
-        mt-[-170px]
-    `}
-`;
-
 const Container = styled.div`
     ${tw`
         mt-[50px] flex flex-col items-center relative w-full
     `}
-`;
-
-const ChallengeSlider = styled.div`
-    ${tw`
-    grid grid-cols-2  gap-[23px]
-`}
 `;

--- a/src/components/Challenge/ChainChallenge.tsx
+++ b/src/components/Challenge/ChainChallenge.tsx
@@ -2,28 +2,27 @@ import styled from "styled-components";
 import tw from "twin.macro";
 import ContentHeader from "../Common/ContentHeader";
 import LeftArrowIcon from "../../assets/icons/left-arrow";
-import { Swiper, SwiperClass, SwiperSlide } from "swiper/react";
 import { ChallengeItemLarge } from "./ChallengeItem";
 import RightArrowIcon from "../../assets/icons/right-arrow";
-import { useEffect, useRef, useState } from "react";
-import { Navigation } from "swiper/modules";
-import "swiper/css";
-import "swiper/css/grid";
-import "swiper/css/pagination";
 import chain from "../../assets/images/challenge_chain.png";
-const ChainChallenge = () => {
-    const prevRef = useRef<HTMLButtonElement>(null);
-    const nextRef = useRef<HTMLButtonElement>(null);
-    const [swiperInstance, setSwiperInstance] = useState<SwiperClass | null>(
-        null
-    );
+import { useState } from "react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { getPartnershipChallenges } from "../../apis/challenge";
 
-    useEffect(() => {
-        if (swiperInstance) {
-            swiperInstance.navigation?.init();
-            swiperInstance.navigation?.update();
-        }
-    }, [swiperInstance]);
+const ChainChallenge = () => {
+    const [page, setPage] = useState<number>(0);
+
+    const { data: challengeData, isLoading } = useQuery({
+        queryKey: ["getPartnershipChallenges", page],
+        queryFn: () => getPartnershipChallenges(page, 2),
+        enabled: true,
+        placeholderData: keepPreviousData,
+    });
+
+    if (isLoading) return <div></div>;
+
+    console.log(challengeData);
+
     return (
         <Container>
             <ContentHeader
@@ -32,99 +31,32 @@ const ChainChallenge = () => {
                 imgSrc={chain}
             />
             <ChallengerContainer>
-                <button ref={prevRef}>
+                <button onClick={() => setPage(page - 1)} disabled={page === 0}>
                     <LeftArrowIcon width={24} height={51} />
                 </button>
-                <StyledSwiper
-                    onSwiper={setSwiperInstance}
-                    slidesPerView={2}
-                    spaceBetween={23}
-                    pagination={{
-                        clickable: true,
-                    }}
-                    modules={[Navigation]}
-                    navigation={{
-                        prevEl: prevRef.current,
-                        nextEl: nextRef.current,
-                    }}
+                <ChallengeSlider>
+                    {challengeData.data.content.map(
+                        (challenge: any, index: number) => (
+                            <ChallengeItemLarge
+                                key={index}
+                                title={challenge.title}
+                                bubbleType={challenge.type}
+                                heartCount={challenge.likeCount}
+                                challengeTypes={challenge.categories}
+                                description={challenge.description}
+                                successRate={challenge.successRate}
+                                participants={challenge.participantCount}
+                                startDate={challenge.startDate}
+                                endDate={challenge.endDate}
+                                supportContent={challenge.supportContent}
+                            />
+                        )
+                    )}
+                </ChallengeSlider>
+                <button
+                    onClick={() => setPage(page + 1)}
+                    disabled={challengeData.data.last}
                 >
-                    <SwiperSlide>
-                        <ChallengeItemLarge
-                            title="1주 1권 독서하기"
-                            heartCount={3}
-                            challengeTypes={["명상", "자기계발"]}
-                            description="매일 1분, 나를 위한 명상으로 하루를 시작해보세요!"
-                            successRate={75}
-                            participants={123}
-                            date="2021.09.01 ~ 2021.09.30"
-                            benefits={[
-                                {
-                                    title: "맞춤형 주거지원",
-                                    price: "최대 300만원",
-                                },
-                                {
-                                    title: "자격증 취득 지원",
-                                    price: "최대 100만원",
-                                },
-                                {
-                                    title: "자격증 취득 격려금",
-                                    price: "인당 30만원",
-                                },
-                            ]}
-                        />
-                    </SwiperSlide>
-                    <SwiperSlide>
-                        <ChallengeItemLarge
-                            title="1주 1권 독서하기"
-                            heartCount={3}
-                            challengeTypes={["명상", "자기계발"]}
-                            description="매일 1분, 나를 위한 명상으로 하루를 시작해보세요!"
-                            successRate={75}
-                            participants={123}
-                            date="2021.09.01 ~ 2021.09.30"
-                            benefits={[
-                                {
-                                    title: "맞춤형 주거지원",
-                                    price: "최대 300만원",
-                                },
-                                {
-                                    title: "자격증 취득 지원",
-                                    price: "최대 100만원",
-                                },
-                                {
-                                    title: "자격증 취득 격려금",
-                                    price: "인당 30만원",
-                                },
-                            ]}
-                        />
-                    </SwiperSlide>
-                    <SwiperSlide>
-                        <ChallengeItemLarge
-                            title="1주 1권 독서하기"
-                            heartCount={3}
-                            challengeTypes={["명상", "자기계발"]}
-                            description="매일 1분, 나를 위한 명상으로 하루를 시작해보세요!"
-                            successRate={75}
-                            participants={123}
-                            date="2021.09.01 ~ 2021.09.30"
-                            benefits={[
-                                {
-                                    title: "맞춤형 주거지원",
-                                    price: "최대 300만원",
-                                },
-                                {
-                                    title: "자격증 취득 지원",
-                                    price: "최대 100만원",
-                                },
-                                {
-                                    title: "자격증 취득 격려금",
-                                    price: "인당 30만원",
-                                },
-                            ]}
-                        />
-                    </SwiperSlide>
-                </StyledSwiper>
-                <button ref={nextRef}>
                     <RightArrowIcon width={24} height={51} />
                 </button>
             </ChallengerContainer>
@@ -150,8 +82,8 @@ const Container = styled.div`
     `}
 `;
 
-const StyledSwiper = styled(Swiper)`
+const ChallengeSlider = styled.div`
     ${tw`
-        w-[1280px]
-    `}
+    grid grid-cols-2  gap-[23px]
+`}
 `;

--- a/src/components/Challenge/ChainChallengeList.tsx
+++ b/src/components/Challenge/ChainChallengeList.tsx
@@ -1,46 +1,26 @@
-import { useEffect, useState } from "react";
 import styled from "styled-components";
 import tw from "twin.macro";
 import LeftArrowIcon from "../../assets/icons/left-arrow";
-import { ChallengeItem } from "./ChallengeItem";
+import { ChallengeItemLarge } from "./ChallengeItem";
 import RightArrowIcon from "../../assets/icons/right-arrow";
-import { getChallenges } from "../../apis/challenge";
+import { useState } from "react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import { on } from "events";
+import { getPartnershipChallenges } from "../../apis/challenge";
+import { ChallengeGridProps } from "./ChainChallenge";
 
-type ChallengeGridProps = {
-    type: string;
-    categories?: string[];
-    size?: number;
-    onePage?: boolean;
-};
-
-const ChallengeGrid = ({
-    type,
-    categories,
-    size,
-    onePage = false,
-}: ChallengeGridProps) => {
+const ChainChallengeList = ({ onePage = false }: ChallengeGridProps) => {
     const [page, setPage] = useState<number>(0);
-    const isCategory = categories !== undefined;
-    const {
-        data: challengeData,
-        isLoading,
-        error,
-    } = useQuery({
-        queryKey: ["getChallengeData", page, type, categories || []],
-        queryFn: () => getChallenges(page, size || 8, type, categories || []),
+
+    const { data: challengeData, isLoading } = useQuery({
+        queryKey: ["getPartnershipChallenges", page],
+        queryFn: () => getPartnershipChallenges(page, 2),
         enabled: true,
         placeholderData: keepPreviousData,
     });
 
-    useEffect(() => {
-        setPage(0);
-    }, [categories]);
-
     if (isLoading) return <div></div>;
-    if (challengeData === undefined) return <div></div>;
 
+    console.log(challengeData);
     return (
         <ChallengerContainer>
             {!onePage && (
@@ -51,16 +31,18 @@ const ChallengeGrid = ({
             <ChallengeSlider>
                 {challengeData.data.content.map(
                     (challenge: any, index: number) => (
-                        <ChallengeItem
+                        <ChallengeItemLarge
                             key={index}
                             title={challenge.title}
-                            bubbleType={type.toString()}
+                            bubbleType={challenge.type}
                             heartCount={challenge.likeCount}
                             challengeTypes={challenge.categories}
                             description={challenge.description}
                             successRate={challenge.successRate}
                             participants={challenge.participantCount}
-                            isCategory={isCategory}
+                            startDate={challenge.startDate}
+                            endDate={challenge.endDate}
+                            supportContent={challenge.supportContent}
                         />
                     )
                 )}
@@ -76,7 +58,8 @@ const ChallengeGrid = ({
         </ChallengerContainer>
     );
 };
-export default ChallengeGrid;
+
+export default ChainChallengeList;
 
 const ChallengerContainer = styled.div`
     ${tw`
@@ -84,13 +67,12 @@ const ChallengerContainer = styled.div`
         items-center
         justify-between
         gap-[40px]
-        mt-[-80px]
-        w-[1400px]
+        mt-[-170px]
     `}
 `;
 
 const ChallengeSlider = styled.div`
     ${tw`
-    grid grid-cols-4 grid-rows-2 gap-[23px]
+    grid grid-cols-2  gap-[23px]
 `}
 `;

--- a/src/components/Challenge/ChallengeGrid.tsx
+++ b/src/components/Challenge/ChallengeGrid.tsx
@@ -30,8 +30,6 @@ const ChallengeGrid = ({ type, categories }: ChallengeGridProps) => {
         setPage(0);
     }, [categories]);
 
-    console.log(challengeData);
-
     if (isLoading) return <div></div>;
     if (challengeData === undefined) return <div></div>;
 

--- a/src/components/Challenge/ChallengeGrid.tsx
+++ b/src/components/Challenge/ChallengeGrid.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 import tw from "twin.macro";
 import LeftArrowIcon from "../../assets/icons/left-arrow";
@@ -14,18 +14,26 @@ type ChallengeGridProps = {
 
 const ChallengeGrid = ({ type, categories }: ChallengeGridProps) => {
     const [page, setPage] = useState<number>(0);
+    const isCategory = categories !== undefined;
     const {
         data: challengeData,
         isLoading,
         error,
     } = useQuery({
-        queryKey: ["getChallengeData", page],
-        queryFn: () => getChallenges(page, 8, type, categories),
+        queryKey: ["getChallengeData", page, type, categories || []],
+        queryFn: () => getChallenges(page, 8, type, categories || []),
         enabled: true,
         placeholderData: keepPreviousData,
     });
 
+    useEffect(() => {
+        setPage(0);
+    }, [categories]);
+
+    console.log(challengeData);
+
     if (isLoading) return <div></div>;
+    if (challengeData === undefined) return <div></div>;
 
     return (
         <ChallengerContainer>
@@ -44,6 +52,7 @@ const ChallengeGrid = ({ type, categories }: ChallengeGridProps) => {
                             description={challenge.description}
                             successRate={challenge.successRate}
                             participants={challenge.participantCount}
+                            isCategory={isCategory}
                         />
                     )
                 )}
@@ -66,6 +75,7 @@ const ChallengerContainer = styled.div`
         justify-between
         gap-[40px]
         mt-[-80px]
+        w-[1400px]
     `}
 `;
 

--- a/src/components/Challenge/ChallengeItem.tsx
+++ b/src/components/Challenge/ChallengeItem.tsx
@@ -8,6 +8,7 @@ import ProgressBar from "../Common/ProgressBar";
 import Heart from "../Common/Heart";
 import Benefit, { BenefitProps } from "./Benefit";
 import { challengeType } from "../../@types/challenge-category";
+import { useCallback } from "react";
 
 interface ChallengeItemProps {
     title: string;
@@ -79,8 +80,9 @@ interface ChallengeLargeItemProps {
     description: string;
     successRate: number;
     participants: number;
-    benefits?: BenefitProps[];
-    date: string;
+    startDate: string;
+    endDate: string;
+    supportContent?: string;
 }
 
 const ChallengeItemLarge = ({
@@ -92,18 +94,41 @@ const ChallengeItemLarge = ({
     description,
     successRate,
     participants,
-    benefits,
-    date,
+    startDate,
+    endDate,
+    supportContent,
 }: ChallengeLargeItemProps) => {
     let BubbleType = null;
+    let supportTitle = "";
     if (bubbleType) {
         BubbleType =
-            bubbleType === "partnership"
+            bubbleType === "PARTNERSHIP"
                 ? BubblePartnership
                 : BubbleOrganization;
     }
 
+    const formDate = useCallback((startDate: string, endDate: string) => {
+        const start = startDate.split("-");
+        const end = endDate.split("-");
+        return `${start[0]}년 ${start[1]}월 ${start[2]}일 - ${end[0]}년 ${end[1]}월 ${end[2]}일`;
+    }, []);
+
     const hasPartners = !!(partnerImages && partnerImages.length > 0);
+
+    const parseCampaignText = (text: string) => {
+        const [title, rest] = text.split(",");
+        const price = rest.replace("지원", "").trim();
+        return {
+            title: title.trim(),
+            price,
+        };
+    };
+
+    if (supportContent) {
+        const { title, price } = parseCampaignText(supportContent);
+        supportTitle = title;
+        supportContent = price;
+    }
 
     return (
         <Container>
@@ -125,7 +150,13 @@ const ChallengeItemLarge = ({
                     </ChallengeHeader>
                     <ChallengeTypeList>
                         {challengeTypes.map((type, index) => (
-                            <ChallengeType key={index}>{type}</ChallengeType>
+                            <ChallengeType key={index}>
+                                {
+                                    challengeType.find(
+                                        (item) => item.id === type
+                                    )?.label
+                                }
+                            </ChallengeType>
                         ))}
                     </ChallengeTypeList>
                 </div>
@@ -136,7 +167,7 @@ const ChallengeItemLarge = ({
                         </ChallengeDescriptionLarge>
                         <ChallengeParticipants>
                             <ParticipantText>
-                                <span>{successRate}% 성공!</span>
+                                <span>{successRate.toFixed(1)}% 성공!</span>
                                 <span>{participants}명 참여</span>
                             </ParticipantText>
                             <ProgressBar rate={successRate} />
@@ -144,15 +175,14 @@ const ChallengeItemLarge = ({
                     </LeftSection>
                     <RightSection>
                         <BenefitList>
-                            {benefits?.map((benefit, index) => (
+                            {supportContent && (
                                 <Benefit
-                                    key={index}
-                                    title={benefit.title}
-                                    price={benefit.price}
+                                    title={supportTitle}
+                                    price={supportContent}
                                 />
-                            ))}
+                            )}
                         </BenefitList>
-                        <Date>{date}</Date>
+                        <Date>{formDate(startDate, endDate)}</Date>
                     </RightSection>
                 </BodyContainer>
             </BackgroundLarge>

--- a/src/components/Challenge/ChallengeItem.tsx
+++ b/src/components/Challenge/ChallengeItem.tsx
@@ -17,6 +17,7 @@ interface ChallengeItemProps {
     description: string;
     successRate: number;
     participants: number;
+    isCategory?: boolean;
 }
 
 const ChallengeItem = ({
@@ -27,11 +28,14 @@ const ChallengeItem = ({
     description,
     successRate,
     participants,
+    isCategory,
 }: ChallengeItemProps) => {
     let BubbleType = null;
-    if (bubbleType) {
-        BubbleType = bubbleType === "popular" ? BubbleHot : BubbleNew;
-    }
+    if (!isCategory) {
+        if (bubbleType) {
+            BubbleType = bubbleType === "popular" ? BubbleHot : BubbleNew;
+        }
+    } else bubbleType = undefined;
     return (
         <Container>
             {bubbleType && <Bubble src={BubbleType} alt="bubble-hot" />}

--- a/src/components/Common/Button.tsx
+++ b/src/components/Common/Button.tsx
@@ -7,6 +7,7 @@ interface ButtonProps {
     mainColor?: boolean;
     small?: boolean;
     background?: string;
+    margin?: boolean;
 }
 
 const Button = ({
@@ -15,6 +16,7 @@ const Button = ({
     mainColor,
     small,
     background = "color",
+    margin = true,
 }: ButtonProps) => {
     return (
         <ButtonContainer
@@ -23,6 +25,7 @@ const Button = ({
             mainColor={mainColor}
             small={small}
             background={background}
+            margin={margin}
         >
             {title}
         </ButtonContainer>
@@ -33,6 +36,7 @@ interface ButtonContainerProps {
     mainColor?: boolean;
     small?: boolean;
     background?: string;
+    margin?: boolean;
 }
 
 const ButtonContainer = styled.button<ButtonContainerProps>`
@@ -62,7 +66,7 @@ const ButtonContainer = styled.button<ButtonContainerProps>`
     ${({ background, mainColor }) =>
         background === "white" && mainColor && tw`text-mainColor`}
 
-    margin-top: auto;
+    ${({ margin }) => margin && tw`mt-auto`}
 `;
 
 export default Button;

--- a/src/components/Main/ChallengeSection.tsx
+++ b/src/components/Main/ChallengeSection.tsx
@@ -5,99 +5,29 @@ import ContentHeader from "../Common/ContentHeader";
 import { ChallengeItem, ChallengeItemLarge } from "../Challenge/ChallengeItem";
 import Partner1 from "../../assets/images/partner1.png";
 import Partner2 from "../../assets/images/partner2.png";
-
-const challengeList = [
-    {
-        title: "1주 1권 독서하기",
-        bubbleType: "hot",
-        heartCount: 3,
-        challengeTypes: ["명상", "자기계발"],
-        description: "매일 1분, 나를 위한 명상으로 하루를 시작해보세요!",
-        successRate: 75,
-        participants: 123,
-    },
-    {
-        title: "1주 1권 독서하기",
-        bubbleType: "new",
-        heartCount: 3,
-        challengeTypes: ["명상", "자기계발"],
-        description: "매일 1분, 나를 위한 명상으로 하루를 시작해보세요!",
-        successRate: 75,
-        participants: 123,
-    },
-    {
-        title: "1주 1권 독서하기",
-        bubbleType: "hot",
-        heartCount: 3,
-        challengeTypes: ["명상", "자기계발"],
-        description: "매일 1분, 나를 위한 명상으로 하루를 시작해보세요!",
-        successRate: 75,
-        participants: 123,
-    },
-    {
-        title: "1주 1권 독서하기",
-        bubbleType: "new",
-        heartCount: 3,
-        challengeTypes: ["명상", "자기계발"],
-        description: "매일 1분, 나를 위한 명상으로 하루를 시작해보세요!",
-        successRate: 75,
-        participants: 123,
-    },
-];
-
-const LargeChallengeList = [
-    {
-        title: "현대캐피탈 자립준비청년 지원프로그램",
-        bubbleType: "partnership",
-        heartCount: 3,
-        challengeTypes: ["금융", "재정관리", "생활", "자격증", "주거"],
-        description:
-            "본 사업은 주거지원비 및 생활환경조성비, 자격증취득지원 및 취득 격려금, 1:1 맞춤 금융경제교육을 진행하는 사업입니다.  ",
-        successRate: 75,
-        participants: 123,
-        partnerImages: [Partner1, Partner2],
-        benefits: [
-            { title: "맞춤형 주거지원", price: "최대 300만원" },
-            { title: "자격증 취득 지원", price: "최대 100만원" },
-            { title: "자격증 취득 격려금", price: "인당 30만원" },
-        ],
-        date: "2024년 4월-2024년 12월",
-    },
-    {
-        title: "현대캐피탈 자립준비청년 지원프로그램",
-        bubbleType: "org",
-        heartCount: 3,
-        challengeTypes: ["금융", "재정관리", "생활", "자격증", "주거"],
-        description:
-            "본 사업은 주거지원비 및 생활환경조성비, 자격증취득지원 및 취득 격려금, 1:1 맞춤 금융경제교육을 진행하는 사업입니다.  ",
-        successRate: 75,
-        participants: 123,
-        benefits: [
-            { title: "맞춤형 주거지원", price: "최대 300만원" },
-            { title: "자격증 취득 지원", price: "최대 100만원" },
-            { title: "자격증 취득 격려금", price: "인당 30만원" },
-        ],
-        date: "2024년 4월-2024년 12월",
-    },
-];
+import { useNavigate } from "react-router-dom";
+import ChallengeGrid from "../Challenge/ChallengeGrid";
+import ChainChallengeList from "../Challenge/ChainChallengeList";
 
 const ChallengeSection = () => {
+    const navigate = useNavigate();
     return (
         <Contents>
             <ContentHeader
                 title="챌린지"
                 desc="스스로 자립능력을 키워나갈 수 있는 기회! 지금 바로 도전하고, 성장하는 자신을 만나보세요!"
+                onClick={() => {
+                    navigate("/challenge");
+                    window.scrollTo(0, 0);
+                }}
             />
             <ChallengeList>
-                {challengeList.map((challenge, index) => (
-                    <ChallengeItem key={index} {...challenge} />
-                ))}
+                <ChallengeGrid type="new" size={4} onePage={true} />
+                <div className="position-control">
+                    <ChainChallengeList onePage={true} />
+                </div>
             </ChallengeList>
-            <ChallengeList>
-                {/* {LargeChallengeList.map((challenge, index) => (
-          // <ChallengeItemLarge key={index} {...challenge} />
-        ))} */}
-            </ChallengeList>
+
             <MedalImage src={Medal} alt="medal" />
         </Contents>
     );
@@ -107,10 +37,13 @@ export default ChallengeSection;
 
 const ChallengeList = styled.div`
     ${tw`
-        flex
-        gap-[23px]
-        mt-[56px]
+        flex flex-col mt-[140px]
     `}
+    .position-control {
+        ${tw`
+        mt-[-80px]
+     `}
+    }
 `;
 
 const Contents = styled.div`

--- a/src/components/Main/ChallengeSection.tsx
+++ b/src/components/Main/ChallengeSection.tsx
@@ -7,106 +7,106 @@ import Partner1 from "../../assets/images/partner1.png";
 import Partner2 from "../../assets/images/partner2.png";
 
 const challengeList = [
-  {
-    title: "1주 1권 독서하기",
-    bubbleType: "hot",
-    heartCount: 3,
-    challengeTypes: ["명상", "자기계발"],
-    description: "매일 1분, 나를 위한 명상으로 하루를 시작해보세요!",
-    successRate: 75,
-    participants: 123,
-  },
-  {
-    title: "1주 1권 독서하기",
-    bubbleType: "new",
-    heartCount: 3,
-    challengeTypes: ["명상", "자기계발"],
-    description: "매일 1분, 나를 위한 명상으로 하루를 시작해보세요!",
-    successRate: 75,
-    participants: 123,
-  },
-  {
-    title: "1주 1권 독서하기",
-    bubbleType: "hot",
-    heartCount: 3,
-    challengeTypes: ["명상", "자기계발"],
-    description: "매일 1분, 나를 위한 명상으로 하루를 시작해보세요!",
-    successRate: 75,
-    participants: 123,
-  },
-  {
-    title: "1주 1권 독서하기",
-    bubbleType: "new",
-    heartCount: 3,
-    challengeTypes: ["명상", "자기계발"],
-    description: "매일 1분, 나를 위한 명상으로 하루를 시작해보세요!",
-    successRate: 75,
-    participants: 123,
-  },
+    {
+        title: "1주 1권 독서하기",
+        bubbleType: "hot",
+        heartCount: 3,
+        challengeTypes: ["명상", "자기계발"],
+        description: "매일 1분, 나를 위한 명상으로 하루를 시작해보세요!",
+        successRate: 75,
+        participants: 123,
+    },
+    {
+        title: "1주 1권 독서하기",
+        bubbleType: "new",
+        heartCount: 3,
+        challengeTypes: ["명상", "자기계발"],
+        description: "매일 1분, 나를 위한 명상으로 하루를 시작해보세요!",
+        successRate: 75,
+        participants: 123,
+    },
+    {
+        title: "1주 1권 독서하기",
+        bubbleType: "hot",
+        heartCount: 3,
+        challengeTypes: ["명상", "자기계발"],
+        description: "매일 1분, 나를 위한 명상으로 하루를 시작해보세요!",
+        successRate: 75,
+        participants: 123,
+    },
+    {
+        title: "1주 1권 독서하기",
+        bubbleType: "new",
+        heartCount: 3,
+        challengeTypes: ["명상", "자기계발"],
+        description: "매일 1분, 나를 위한 명상으로 하루를 시작해보세요!",
+        successRate: 75,
+        participants: 123,
+    },
 ];
 
 const LargeChallengeList = [
-  {
-    title: "현대캐피탈 자립준비청년 지원프로그램",
-    bubbleType: "partnership",
-    heartCount: 3,
-    challengeTypes: ["금융", "재정관리", "생활", "자격증", "주거"],
-    description:
-      "본 사업은 주거지원비 및 생활환경조성비, 자격증취득지원 및 취득 격려금, 1:1 맞춤 금융경제교육을 진행하는 사업입니다.  ",
-    successRate: 75,
-    participants: 123,
-    partnerImages: [Partner1, Partner2],
-    benefits: [
-      { title: "맞춤형 주거지원", price: "최대 300만원" },
-      { title: "자격증 취득 지원", price: "최대 100만원" },
-      { title: "자격증 취득 격려금", price: "인당 30만원" },
-    ],
-    date: "2024년 4월-2024년 12월",
-  },
-  {
-    title: "현대캐피탈 자립준비청년 지원프로그램",
-    bubbleType: "org",
-    heartCount: 3,
-    challengeTypes: ["금융", "재정관리", "생활", "자격증", "주거"],
-    description:
-      "본 사업은 주거지원비 및 생활환경조성비, 자격증취득지원 및 취득 격려금, 1:1 맞춤 금융경제교육을 진행하는 사업입니다.  ",
-    successRate: 75,
-    participants: 123,
-    benefits: [
-      { title: "맞춤형 주거지원", price: "최대 300만원" },
-      { title: "자격증 취득 지원", price: "최대 100만원" },
-      { title: "자격증 취득 격려금", price: "인당 30만원" },
-    ],
-    date: "2024년 4월-2024년 12월",
-  },
+    {
+        title: "현대캐피탈 자립준비청년 지원프로그램",
+        bubbleType: "partnership",
+        heartCount: 3,
+        challengeTypes: ["금융", "재정관리", "생활", "자격증", "주거"],
+        description:
+            "본 사업은 주거지원비 및 생활환경조성비, 자격증취득지원 및 취득 격려금, 1:1 맞춤 금융경제교육을 진행하는 사업입니다.  ",
+        successRate: 75,
+        participants: 123,
+        partnerImages: [Partner1, Partner2],
+        benefits: [
+            { title: "맞춤형 주거지원", price: "최대 300만원" },
+            { title: "자격증 취득 지원", price: "최대 100만원" },
+            { title: "자격증 취득 격려금", price: "인당 30만원" },
+        ],
+        date: "2024년 4월-2024년 12월",
+    },
+    {
+        title: "현대캐피탈 자립준비청년 지원프로그램",
+        bubbleType: "org",
+        heartCount: 3,
+        challengeTypes: ["금융", "재정관리", "생활", "자격증", "주거"],
+        description:
+            "본 사업은 주거지원비 및 생활환경조성비, 자격증취득지원 및 취득 격려금, 1:1 맞춤 금융경제교육을 진행하는 사업입니다.  ",
+        successRate: 75,
+        participants: 123,
+        benefits: [
+            { title: "맞춤형 주거지원", price: "최대 300만원" },
+            { title: "자격증 취득 지원", price: "최대 100만원" },
+            { title: "자격증 취득 격려금", price: "인당 30만원" },
+        ],
+        date: "2024년 4월-2024년 12월",
+    },
 ];
 
 const ChallengeSection = () => {
-  return (
-    <Contents>
-      <ContentHeader
-        title="챌린지"
-        desc="스스로 자립능력을 키워나갈 수 있는 기회! 지금 바로 도전하고, 성장하는 자신을 만나보세요!"
-      />
-      <ChallengeList>
-        {challengeList.map((challenge, index) => (
-          <ChallengeItem key={index} {...challenge} />
-        ))}
-      </ChallengeList>
-      <ChallengeList>
-        {LargeChallengeList.map((challenge, index) => (
-          <ChallengeItemLarge key={index} {...challenge} />
-        ))}
-      </ChallengeList>
-      <MedalImage src={Medal} alt="medal" />
-    </Contents>
-  );
+    return (
+        <Contents>
+            <ContentHeader
+                title="챌린지"
+                desc="스스로 자립능력을 키워나갈 수 있는 기회! 지금 바로 도전하고, 성장하는 자신을 만나보세요!"
+            />
+            <ChallengeList>
+                {challengeList.map((challenge, index) => (
+                    <ChallengeItem key={index} {...challenge} />
+                ))}
+            </ChallengeList>
+            <ChallengeList>
+                {/* {LargeChallengeList.map((challenge, index) => (
+          // <ChallengeItemLarge key={index} {...challenge} />
+        ))} */}
+            </ChallengeList>
+            <MedalImage src={Medal} alt="medal" />
+        </Contents>
+    );
 };
 
 export default ChallengeSection;
 
 const ChallengeList = styled.div`
-  ${tw`
+    ${tw`
         flex
         gap-[23px]
         mt-[56px]
@@ -114,7 +114,7 @@ const ChallengeList = styled.div`
 `;
 
 const Contents = styled.div`
-  ${tw`
+    ${tw`
         flex
         flex-col
         w-[1280px]
@@ -123,7 +123,7 @@ const Contents = styled.div`
 `;
 
 const MedalImage = styled.img`
-  ${tw`
+    ${tw`
         w-[336px]
         h-[427px]
         absolute

--- a/src/components/MyPage/CanaryModal.tsx
+++ b/src/components/MyPage/CanaryModal.tsx
@@ -11,6 +11,7 @@ import { postCanaryApply } from "../../apis/canary";
 
 const CanaryModal = ({ onClick }: { onClick: () => void }) => {
     const { userData } = useAuthStore.getState();
+    const [success, setSuccess] = useState(false);
     const [image, setImage] = useState<File | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const accesstoken = useAuthStore((state) => state.accessToken)!;
@@ -90,116 +91,150 @@ const CanaryModal = ({ onClick }: { onClick: () => void }) => {
             const birth = convertToISO(+year, +month, +day);
             uploadApplyData.birth = birth;
             const res = await postCanaryApply(uploadApplyData, accesstoken);
-            if (res.success) {
-                onClick();
+            if (res ? res.success : false) {
+                setSuccess(true);
             } else {
                 alert("제출에 실패했습니다.");
             }
         }
-    }, [accesstoken, applyData, handleApplyData, image, onClick, birthData]);
+    }, [accesstoken, applyData, image, birthData]);
     return (
         <CanaryWrapper
             onClick={() => {
                 onClick();
             }}
         >
-            <Canary
-                onClick={(e) => {
-                    e.stopPropagation();
-                }}
-            >
-                <span className="title-text">자립준비청년 인증하기</span>
-                <div className="input-section main-text">
-                    <div className="sub-section">
-                        <div className="w-[662.79px]">
-                            <span className="sub-text">
-                                보호종료확인서 업로드
-                            </span>
-                            <ImageInput>
-                                <div className="input-field">
-                                    <Input
-                                        type="file"
-                                        onChange={handleImageChange}
-                                        style={{ display: "none" }} // Hide the file input
-                                        ref={fileInputRef} // Use a ref to interact with this input
+            {!success ? (
+                <Canary
+                    onClick={(e) => {
+                        e.stopPropagation();
+                    }}
+                >
+                    <span className="title-text">자립준비청년 인증하기</span>
+                    <div className="input-section main-text">
+                        <div className="sub-section">
+                            <div className="w-[662.79px]">
+                                <span className="sub-text">
+                                    보호종료확인서 업로드
+                                </span>
+                                <ImageInput>
+                                    <div className="input-field">
+                                        <Input
+                                            type="file"
+                                            onChange={handleImageChange}
+                                            style={{ display: "none" }} // Hide the file input
+                                            ref={fileInputRef} // Use a ref to interact with this input
+                                        />
+                                        <span>{image?.name || ""}</span>
+                                    </div>
+                                    <Button
+                                        title="업로드"
+                                        mainColor
+                                        small
+                                        onClick={() =>
+                                            fileInputRef.current?.click()
+                                        }
                                     />
-                                    <span>{image?.name || ""}</span>
-                                </div>
-                                <Button
-                                    title="업로드"
-                                    mainColor
-                                    small
-                                    onClick={() =>
-                                        fileInputRef.current?.click()
+                                </ImageInput>
+                            </div>
+                        </div>
+                        <div className="sub-section">
+                            <div className="w-[303.19px]">
+                                <span className="sub-text">휴대폰 번호</span>
+                                <Input
+                                    placeholder="010-1234-5678"
+                                    onChange={(e) =>
+                                        handleApplyData(e.target.value, "phone")
+                                    }
+                                    value={applyData.phone.toString()}
+                                />
+                            </div>
+                            <div className="birth">
+                                <DropDown
+                                    hint="생년월일"
+                                    type="year"
+                                    value={birthData.year + "년"}
+                                    onChange={(e) =>
+                                        handleBirthData(e.target.value, "year")
                                     }
                                 />
-                            </ImageInput>
+                                <DropDown
+                                    type="month"
+                                    width="110px"
+                                    value={birthData.month + "월"}
+                                    onChange={(e) =>
+                                        handleBirthData(e.target.value, "month")
+                                    }
+                                />
+                                <DropDown
+                                    type="day"
+                                    width="110px"
+                                    value={birthData.day + "일"}
+                                    onChange={(e) =>
+                                        handleBirthData(e.target.value, "day")
+                                    }
+                                />
+                            </div>
+                            <div>
+                                <DropDown
+                                    hint="성별"
+                                    items={["남성", "여성"]}
+                                    value={
+                                        applyData.gender === true
+                                            ? "남성"
+                                            : "여성"
+                                    }
+                                    onChange={(e) =>
+                                        handleApplyData(
+                                            e.target.value === "남성",
+                                            "gender"
+                                        )
+                                    }
+                                />
+                            </div>
                         </div>
+                        <PostalCode onChange={handleAddressChange} />
                     </div>
-                    <div className="sub-section">
-                        <div className="w-[303.19px]">
-                            <span className="sub-text">휴대폰 번호</span>
-                            <Input
-                                placeholder="010-1234-5678"
-                                onChange={(e) =>
-                                    handleApplyData(e.target.value, "phone")
-                                }
-                                value={applyData.phone.toString()}
-                            />
-                        </div>
-                        <div className="birth">
-                            <DropDown
-                                hint="생년월일"
-                                type="year"
-                                value={birthData.year + "년"}
-                                onChange={(e) =>
-                                    handleBirthData(e.target.value, "year")
-                                }
-                            />
-                            <DropDown
-                                type="month"
-                                width="110px"
-                                value={birthData.month + "월"}
-                                onChange={(e) =>
-                                    handleBirthData(e.target.value, "month")
-                                }
-                            />
-                            <DropDown
-                                type="day"
-                                width="110px"
-                                value={birthData.day + "일"}
-                                onChange={(e) =>
-                                    handleBirthData(e.target.value, "day")
-                                }
-                            />
-                        </div>
-                        <div>
-                            <DropDown
-                                hint="성별"
-                                items={["남성", "여성"]}
-                                value={
-                                    applyData.gender === true ? "남성" : "여성"
-                                }
-                                onChange={(e) =>
-                                    handleApplyData(
-                                        e.target.value === "남성",
-                                        "gender"
-                                    )
-                                }
-                            />
-                        </div>
+                    <div>
+                        <Button title="제출하기" small onClick={onSubmit} />
                     </div>
-                    <PostalCode onChange={handleAddressChange} />
-                </div>
-                <div>
-                    <Button title="제출하기" small onClick={onSubmit} />
-                </div>
-            </Canary>
+                </Canary>
+            ) : (
+                <SuccessModal>
+                    <div className="title-text">인증 서류를 제출했습니다.</div>
+                    <div className="sub-text">
+                        자립준비청년 인증까지 영업일 기준 최대 10일 소요됩니다.
+                    </div>
+                    <Button
+                        title="닫기"
+                        small
+                        background="white"
+                        margin={false}
+                        onClick={onClick}
+                    />
+                </SuccessModal>
+            )}
         </CanaryWrapper>
     );
 };
 
 export default CanaryModal;
+
+const SuccessModal = styled.div`
+    ${tw`
+        w-[636px] h-[294px] rounded-[16px] bg-background flex flex-col justify-center items-center gap-[23px]
+    `}
+    .title-text {
+        ${tw`
+            text-bold-36 font-bold text-fontColor1
+        `}
+    }
+    .sub-text {
+        ${tw`
+            text-medium-20 font-medium text-fontColor3
+        `}
+    }
+`;
 
 const ImageInput = styled.div`
     ${tw`

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -15,63 +15,66 @@ import useAuthStore from "../storage/useAuthStore";
 import { getUserInfo } from "../apis/user";
 
 function Main() {
-  // redirection 주소로 부터 accessToken을 받아와서 localStorage에 저장
-  const location = useLocation();
-  const navigate = useNavigate();
+    // redirection 주소로 부터 accessToken을 받아와서 localStorage에 저장
+    const location = useLocation();
+    const navigate = useNavigate();
 
-  useEffect(() => {
-    const fetchUserInfo = async () => {
-      const query = new URLSearchParams(location.search);
-      let accessToken = useAuthStore.getState().accessToken;
+    useEffect(() => {
+        const fetchUserInfo = async () => {
+            const query = new URLSearchParams(location.search);
+            let accessToken = useAuthStore.getState().accessToken;
 
-      if (!accessToken) {
-        const token = query.get("accessToken");
-        if (token) {
-          accessToken = token;
-        }
-      }
+            if (!accessToken) {
+                const token = query.get("accessToken");
+                if (token) {
+                    accessToken = token;
+                }
+            }
 
-      if (accessToken && useAuthStore.getState().userData.id === undefined) {
-        try {
-          const res = await getUserInfo(accessToken);
-          if (res.success) {
-            useAuthStore.setState({
-              isLoggedIn: true,
-              userData: res.data,
-              accessToken: accessToken,
-            });
-            navigate("/"); // 사용자 정보 설정 후 홈으로 리디렉션
-          }
-        } catch (error) {
-          console.error("사용자 정보 가져오기 오류:", error);
-        }
-      }
-    };
+            if (
+                accessToken &&
+                useAuthStore.getState().userData.id === undefined
+            ) {
+                try {
+                    const res = await getUserInfo(accessToken);
+                    if (res.success) {
+                        useAuthStore.setState({
+                            isLoggedIn: true,
+                            userData: res.data,
+                            accessToken: accessToken,
+                        });
+                        navigate("/"); // 사용자 정보 설정 후 홈으로 리디렉션
+                    }
+                } catch (error) {
+                    console.error("사용자 정보 가져오기 오류:", error);
+                }
+            }
+        };
 
-    fetchUserInfo();
-  }, [location.search, navigate]);
+        fetchUserInfo();
+    }, [location.search, navigate]);
 
-  return (
-    <DefaultLayout>
-      <TagLine />
-      <Banner />
-      <ContentsContainer>
-        <DonationSection />
-        <ChallengeSection />
-        <MentoringSection />
-        <InformationSection />
-        <FledgeContainer>
-          <Title>fledge 플리지에게 흥미가 생기셨나요?</Title>
-          <Button title="fledge가 뭐에요?" />
-          <img src={Bird} alt="bird" />
-        </FledgeContainer>
-      </ContentsContainer>
-    </DefaultLayout>
-  );
+    return (
+        <DefaultLayout>
+            <TagLine />
+            <Banner />
+            <ContentsContainer>
+                <DonationSection />
+                <ChallengeSection />
+                <MentoringSection />
+                <InformationSection />
+                <FledgeContainer>
+                    <Title>fledge 플리지에게 흥미가 생기셨나요?</Title>
+                    <Button title="fledge가 뭐에요?" />
+                    <img src={Bird} alt="bird" />
+                </FledgeContainer>
+            </ContentsContainer>
+        </DefaultLayout>
+    );
 }
 
 const FledgeContainer = styled.div`
-  ${tw`
+    ${tw`
         flex
         flex-col
         items-center
@@ -81,7 +84,7 @@ const FledgeContainer = styled.div`
 `;
 
 const Title = styled.span`
-  ${tw`
+    ${tw`
         text-bold-64
         font-bold
         text-fontColor1
@@ -89,7 +92,7 @@ const Title = styled.span`
 `;
 
 const ContentsContainer = styled.div`
-  ${tw`
+    ${tw`
         flex
         flex-col
         items-center

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -17,7 +17,7 @@ import CanaryModal from "../components/MyPage/CanaryModal";
 import useAuthStore from "../storage/useAuthStore";
 
 function MyPage() {
-    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [isModalOpen, setIsModalOpen] = useState(true);
     const { userData } = useAuthStore.getState();
     const isCanary = userData.role === "CANARY";
 
@@ -31,7 +31,6 @@ function MyPage() {
             {/* 챌린지 달성 뱃지 */}
             {isCanary && <BadgeBoard />}
 
-
             {/* 후원 인증 히스토리 */}
             {isCanary && (
                 <SponsorWrapper>
@@ -43,12 +42,11 @@ function MyPage() {
                             게시한 후원 게시물과 진행 상황을 확인할 수 있어요.
                         </span>
                     </Header>
-                   {/* <Slider menu="my" /> */}
+                    {/* <Slider menu="my" /> */}
                 </SponsorWrapper>
             )}
             {/* 회원 기본 정보 */}
             <UserBasicInfo />
-
 
             {/* 자립준비청년 인증 */}
             <CanaryAuth onClick={() => setIsModalOpen(true)} />

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -7,17 +7,13 @@ import ProfileHeader from "../components/MyPage/Header";
 import UserBasicInfo from "../components/MyPage/UserBasicInfo";
 import { useState } from "react";
 import BadgeBoard from "../components/MyPage/BadgeBoard";
-import Slider from "../components/Sponsor/Slider";
 import CanaryAuth from "../components/MyPage/CanaryAuth";
-import Input from "../components/Common/Input";
-import DropDown from "../components/Common/DropDown";
-import Button from "../components/Common/Button";
 import PersonalInfo from "../components/MyPage/PersonalInfo";
 import CanaryModal from "../components/MyPage/CanaryModal";
 import useAuthStore from "../storage/useAuthStore";
 
 function MyPage() {
-    const [isModalOpen, setIsModalOpen] = useState(true);
+    const [isModalOpen, setIsModalOpen] = useState(false);
     const { userData } = useAuthStore.getState();
     const isCanary = userData.role === "CANARY";
 


### PR DESCRIPTION
#40 #41

자립준비 청년 인증 모달에서 인증 신청 성공 안내창 추가

챌린지 페이지에서 연계 챌린지, 카테고리 필터링 API 연결